### PR TITLE
Modernise docs links, fix invalid HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
 
   <!-- Latest compiled and minified JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-</script>
 </head>
 
 <body>
@@ -43,11 +42,11 @@
     <div id="main_content" class="inner">
       <div style="float: right; padding: 1em;text-align: center">
         <a href=
-        "http://jeremykun.com/2012/01/01/random-psychedelic-art/"><img class="img-thumbnail"
+        "https://jeremykun.com/2012/01/01/random-psychedelic-art/"><img class="img-thumbnail"
         style="width: 90%" src="/images/img49.png" alt=
         "Random psychedelic art made with Pillow"></a><br>
         <span><a href=
-        "http://jeremykun.com/2012/01/01/random-psychedelic-art/">Random
+        "https://jeremykun.com/2012/01/01/random-psychedelic-art/">Random
         psychedelic art</a> made with PIL</span>
       </div>
 
@@ -65,7 +64,7 @@
       We're here</a> to save the day.</p>
 
       <h3><a href=
-      "https://github.com/python-pillow/Pillow">Code</a></h4>
+      "https://github.com/python-pillow/Pillow">Code</a></h3>
 
       <p>Our code is <a href=
       "https://github.com/python-pillow/Pillow">hosted on
@@ -78,22 +77,22 @@
       PyPI</a>.</p>
 
       <h3><a href=
-      "http://pillow.readthedocs.org/">Documentation</a></h4>
+      "https://pillow.readthedocs.org/">Documentation</a></h3>
 
       <p>Our documentation is <a href=
-      "http://pillow.readthedocs.org">hosted on readthedocs.org</a>
+      "https://pillow.readthedocs.org">hosted on readthedocs.org</a>
       and includes <a href=
-      "http://pillow.readthedocs.org/en/3.0.x/installation.html">installation
+      "https://pillow.readthedocs.io/en/latest/installation.html">installation
       instructions</a>, <a href=
-      "http://pillow.readthedocs.org/en/3.0.x/handbook/index.html">handbook</a>,
+      "https://pillow.readthedocs.io/en/latest/handbook/">handbook</a>,
       <a href=
-      "http://pillow.readthedocs.org/en/3.0.x/reference/index.html">API
+      "https://pillow.readthedocs.io/en/latest/reference/">API
       reference</a>, <a href=
-      "http://pillow.readthedocs.org/en/3.0.x/releasenotes/index.html">release
+      "https://pillow.readthedocs.io/en/latest/releasenotes/">release
       notes</a> and more.</p>
 
       <h3>Discussion</h3>
-      <p>Discussion occurs on <a href="https://github.com/python-pillow/Pillow/issues">GitHub</a>, <a href="http://stackoverflow.com/questions/tagged/pillow">Stack Overflow</a> and <a href="irc://irc.freenode.net#pil">IRC</a>. IRC conversations are <a href="http://chat-logs.dcpython.org/channel/pil">logged here</a>.
+      <p>Discussion occurs on <a href="https://github.com/python-pillow/Pillow/issues">GitHub</a>, <a href="https://stackoverflow.com/questions/tagged/pillow">Stack Overflow</a> and <a href="irc://irc.freenode.net#pil">IRC</a>. IRC conversations are <a href="http://chat-logs.dcpython.org/channel/pil">logged here</a>.
     </div><!-- FOOTER  -->
 
     <div id="footer_wrap" class="outer">
@@ -105,7 +104,7 @@
         Pages</a>. Pillow logo <a href=
         "https://github.com/python-pillow/Pillow/issues/575">created
         by Alastair Houghton</a>. Random psychedelic art by
-        <a href="http://jeremykun.com">Jeremy Kun</a>.</p>
+        <a href="https://jeremykun.com">Jeremy Kun</a>.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This updates the docs links so they always point to the 'latest' version on ReadTheDocs.  I also tidied a few bits of invalid HTML and http --> https in the process.