### PR TITLE
Update and refresh documentation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
 
   <!-- Latest compiled and minified JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-</script>
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -83,13 +83,13 @@
       <p>Our documentation is <a href=
       "https://pillow.readthedocs.io/">hosted on readthedocs.io</a>
       and includes <a href=
-      "https://pillow.readthedocs.io/en/latest/installation.html">installation
+      "https://pillow.readthedocs.io/en/stable/installation.html">installation
       instructions</a>, <a href=
-      "https://pillow.readthedocs.io/en/latest/handbook/index.html">handbook</a>,
+      "https://pillow.readthedocs.io/en/stable/handbook/index.html">handbook</a>,
       <a href=
-      "https://pillow.readthedocs.io/en/latest/reference/index.html">API
+      "https://pillow.readthedocs.io/en/stable/reference/index.html">API
       reference</a>, <a href=
-      "https://pillow.readthedocs.io/en/latest/releasenotes/index.html">release
+      "https://pillow.readthedocs.io/en/stable/releasenotes/index.html">release
       notes</a> and more.</p>
 
       <h3>Discussion</h3>

--- a/index.html
+++ b/index.html
@@ -43,11 +43,11 @@
     <div id="main_content" class="inner">
       <div style="float: right; padding: 1em;text-align: center">
         <a href=
-        "http://jeremykun.com/2012/01/01/random-psychedelic-art/"><img class="img-thumbnail"
+        "https://jeremykun.com/2012/01/01/random-psychedelic-art/"><img class="img-thumbnail"
         style="width: 90%" src="/images/img49.png" alt=
         "Random psychedelic art made with Pillow"></a><br>
         <span><a href=
-        "http://jeremykun.com/2012/01/01/random-psychedelic-art/">Random
+        "https://jeremykun.com/2012/01/01/random-psychedelic-art/">Random
         psychedelic art</a> made with PIL</span>
       </div>
 
@@ -78,22 +78,22 @@
       PyPI</a>.</p>
 
       <h3><a href=
-      "http://pillow.readthedocs.org/">Documentation</a></h4>
+      "https://pillow.readthedocs.io/">Documentation</a></h4>
 
       <p>Our documentation is <a href=
-      "http://pillow.readthedocs.org">hosted on readthedocs.org</a>
+      "https://pillow.readthedocs.io/">hosted on readthedocs.io</a>
       and includes <a href=
-      "http://pillow.readthedocs.org/en/3.0.x/installation.html">installation
+      "https://pillow.readthedocs.io/en/latest/installation.html">installation
       instructions</a>, <a href=
-      "http://pillow.readthedocs.org/en/3.0.x/handbook/index.html">handbook</a>,
+      "https://pillow.readthedocs.io/en/latest/handbook/index.html">handbook</a>,
       <a href=
-      "http://pillow.readthedocs.org/en/3.0.x/reference/index.html">API
+      "https://pillow.readthedocs.io/en/latest/reference/index.html">API
       reference</a>, <a href=
-      "http://pillow.readthedocs.org/en/3.0.x/releasenotes/index.html">release
+      "https://pillow.readthedocs.io/en/latest/releasenotes/index.html">release
       notes</a> and more.</p>
 
       <h3>Discussion</h3>
-      <p>Discussion occurs on <a href="https://github.com/python-pillow/Pillow/issues">GitHub</a>, <a href="http://stackoverflow.com/questions/tagged/pillow">Stack Overflow</a> and <a href="irc://irc.freenode.net#pil">IRC</a>. IRC conversations are <a href="http://chat-logs.dcpython.org/channel/pil">logged here</a>.
+      <p>Discussion occurs on <a href="https://github.com/python-pillow/Pillow/issues">GitHub</a>, <a href="https://stackoverflow.com/questions/tagged/python-imaging-library">Stack Overflow</a> and <a href="irc://irc.freenode.net#pil">IRC</a>. IRC conversations are <a href="http://chat-logs.dcpython.org/channel/pil">logged here</a>.
 
       <h3>More</h3>
       <p>Also check out <a href="http://python-pillow.org/pillow-perf">Pillow Perf</a></p>
@@ -108,7 +108,7 @@
         Pages</a>. Pillow logo <a href=
         "https://github.com/python-pillow/Pillow/issues/575">created
         by Alastair Houghton</a>. Random psychedelic art by
-        <a href="http://jeremykun.com">Jeremy Kun</a>.</p>
+        <a href="https://jeremykun.com/">Jeremy Kun</a>.</p>
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
       We're here</a> to save the day.</p>
 
       <h3><a href=
-      "https://github.com/python-pillow/Pillow">Code</a></h4>
+      "https://github.com/python-pillow/Pillow">Code</a></h3>
 
       <p>Our code is <a href=
       "https://github.com/python-pillow/Pillow">hosted on
@@ -78,7 +78,7 @@
       PyPI</a>.</p>
 
       <h3><a href=
-      "https://pillow.readthedocs.io/">Documentation</a></h4>
+      "https://pillow.readthedocs.io/">Documentation</a></h3>
 
       <p>Our documentation is <a href=
       "https://pillow.readthedocs.io/">hosted on readthedocs.io</a>


### PR DESCRIPTION
* Update RTD links from version 3.0 (outdated) to latest
* Update readthedocs.org to readthedocs.io
* Update HTTP to HTTPS, where appropriate
* Update the `pillow` SO tag to `python-imaging-library`