### PR TITLE
Removed Bootstrap JS

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,9 +17,6 @@
 
   <!-- Optional theme -->
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css">
-
-  <!-- Latest compiled and minified JavaScript -->
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
In the console of the current version of the site, there is 'Uncaught Error: Bootstrap's JavaScript requires jQuery'.

We could add jQuery to solve this. However, I'm not seeing anything that actually uses Bootstrap JS, so this PR removes it.