### PR TITLE
Updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,6 @@
       <div class="col-md-4">
         <h2>Discussion</h2>
         <p>Discussion about Pillow development, programming and technical issues occurs on <a target="_blank" href="https://github.com/python-pillow/Pillow/issues">GitHub</a>, <a target="_blank" href="https://stackoverflow.com/questions/tagged/python-imaging-library">Stack Overflow</a>, <a target="_blank" href="https://gitter.im/python-pillow/Pillow">Gitter</a> and <a target="_blank" href="irc://irc.freenode.net#pil">IRC</a>.</p>
-        <p><a class="btn btn-secondary" href="#" role="button">View details &raquo;</a></p>
       </div>
       <div class="col-md-4">
         <h2>Source Code</h2>

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
       </div>
       <div class="col-md-4">
         <h2>Source Code</h2>
-        <p>Our source code is <a target="_blank" href= "https://github.com/python-pillow/Pillow">hosted on GitHub</a> and tested on <a target="_blank" href="https://travis-ci.org/python-pillow/Pillow">Travis CI</a>, <a target="_blank" href="https://ci.appveyor.com/project/python-pillow/Pillow">AppVeyor</a>, <a target="_blank" href="https://github.com/python-pillow/Pillow/actions">GitHub Actions</a>, <a target="_blank" href="https://codecov.io/gh/python-pillow/Pillow">Codecov</a> and released on the <a href="https://pypi.org/project/Pillow">Python Package Index</a>.</p>
+        <p>Our source code is <a target="_blank" href= "https://github.com/python-pillow/Pillow">hosted on GitHub</a> and tested on <a target="_blank" href="https://travis-ci.org/python-pillow/Pillow">Travis CI</a>, <a target="_blank" href="https://ci.appveyor.com/project/python-pillow/Pillow">AppVeyor</a>, <a target="_blank" href="https://github.com/python-pillow/Pillow/actions">GitHub Actions</a>, <a target="_blank" href="https://codecov.io/gh/python-pillow/Pillow">Codecov</a> and released on the <a target="_blank" href="https://pypi.org/project/Pillow">Python Package Index</a>.</p>
         <p><a target="_blank" class="btn btn-secondary" href="https://github.com/python-pillow/Pillow" role="button"><i class="fab fa-github mr-1"></i>View details &raquo;</a></p>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -40,11 +40,11 @@
   <body>
     <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
   <a class="navbar-brand" href="#"><img src="images/pillow-logo.png"></a>
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsDefault" aria-controls="navbarsDefault" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
 
-  <div class="collapse navbar-collapse" id="navbarsExampleDefault">
+  <div class="collapse navbar-collapse" id="navbarsDefault">
     <ul class="navbar-nav mr-auto">
       <li class="nav-item">
         <a class="nav-link" href="#tidelift">Enterprise</a>
@@ -76,7 +76,6 @@
   </div>
 
   <div class="container">
-    <!-- Example row of columns -->
     <div class="row">
       <div class="col-md-4">
         <h2>Documentation</h2>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="description" content="">
+    <meta name="description" content="Pillow: the friendly PIL fork">
     <meta name="author" content="Mark Otto, Jacob Thornton, and Bootstrap contributors">
     <meta name="generator" content="Jekyll v3.8.6">
     <title>Python Pillow</title>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="Pillow: the friendly PIL fork">
-    <meta name="author" content="Mark Otto, Jacob Thornton, and Bootstrap contributors">
     <meta name="generator" content="Jekyll v3.8.6">
     <title>Python Pillow</title>
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <meta name="generator" content="Jekyll v3.8.6">
     <title>Python Pillow</title>
 
-    <link rel="canonical" href="https://getbootstrap.com/docs/4.4/examples/jumbotron/">
+    <link rel="canonical" href="https://python-pillow.org/">
 
     <!-- Bootstrap core CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">

--- a/jumbotron.css
+++ b/jumbotron.css
@@ -1,4 +1,4 @@
-/* Move down content because we have a fixed navbar that is 3.5rem tall */
+/* Move down content because we have a fixed navbar that is 6.75rem tall */
 body {
-  padding-top: 4.5rem;
+  padding-top: 6.75rem;
 }


### PR DESCRIPTION
* Corrected the canonical URL. See also https://github.com/python-pillow/python-pillow.github.io/pull/20#discussion_r401349770.
* Restored the previous 'description' meta tag, instead of just having an empty string
* Removed the 'author' meta tag
* Removed the middle 'View details' button, since it didn't link to anything. Credit to https://github.com/python-pillow/python-pillow.github.io/pull/20#discussion_r401350381
* Added 'target="_blank"' to the one link that doesn't have it. Credit to https://github.com/python-pillow/python-pillow.github.io/pull/20#discussion_r401351978
* Removed some use of the string 'example'
* Corrected the navbar height. Aside from just being correct now, it also stops the central black box from touching the navbar on mobile.