### PR TITLE
Updated CI links

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
       </div>
       <div class="col-md-4">
         <h2>Source Code</h2>
-        <p>Our source code is <a target="_blank" href= "https://github.com/python-pillow/Pillow">hosted on GitHub</a> and tested on <a target="_blank" href="https://travis-ci.com/github/python-pillow/Pillow">Travis CI</a>, <a target="_blank" href="https://ci.appveyor.com/project/python-pillow/Pillow">AppVeyor</a>, <a target="_blank" href="https://github.com/python-pillow/Pillow/actions">GitHub Actions</a>, <a target="_blank" href="https://codecov.io/gh/python-pillow/Pillow">Codecov</a> and released on the <a target="_blank" href="https://pypi.org/project/Pillow">Python Package Index</a>.</p>
+        <p>Our source code is <a target="_blank" href= "https://github.com/python-pillow/Pillow">hosted on GitHub</a> and tested on <a target="_blank" href="https://travis-ci.com/github/python-pillow/pillow-wheels">Travis CI</a>, <a target="_blank" href="https://ci.appveyor.com/project/python-pillow/Pillow">AppVeyor</a>, <a target="_blank" href="https://github.com/python-pillow/Pillow/actions">GitHub Actions</a>, <a target="_blank" href="https://codecov.io/gh/python-pillow/Pillow">Codecov</a> and released on the <a target="_blank" href="https://pypi.org/project/Pillow">Python Package Index</a>.</p>
         <p><a target="_blank" class="btn btn-secondary" href="https://github.com/python-pillow/Pillow" role="button"><i class="fab fa-github mr-1"></i>View details &raquo;</a></p>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
       </div>
       <div class="col-md-4">
         <h2>Source Code</h2>
-        <p>Our source code is <a target="_blank" href= "https://github.com/python-pillow/Pillow">hosted on GitHub</a> and tested on <a target="_blank" href="https://travis-ci.com/github/python-pillow/pillow-wheels">Travis CI</a>, <a target="_blank" href="https://ci.appveyor.com/project/python-pillow/Pillow">AppVeyor</a>, <a target="_blank" href="https://github.com/python-pillow/Pillow/actions">GitHub Actions</a>, <a target="_blank" href="https://codecov.io/gh/python-pillow/Pillow">Codecov</a> and released on the <a target="_blank" href="https://pypi.org/project/Pillow">Python Package Index</a>.</p>
+        <p>Our source code is <a target="_blank" href= "https://github.com/python-pillow/Pillow">hosted on GitHub</a> and tested on <a target="_blank" href="https://github.com/python-pillow/Pillow/actions">GitHub Actions</a>, <a target="_blank" href="https://ci.appveyor.com/project/python-pillow/Pillow">AppVeyor</a>, <a target="_blank" href="https://travis-ci.com/github/python-pillow/pillow-wheels">Travis CI</a>, <a target="_blank" href="https://codecov.io/gh/python-pillow/Pillow">Codecov</a> and released on the <a target="_blank" href="https://pypi.org/project/Pillow">Python Package Index</a>.</p>
         <p><a target="_blank" class="btn btn-secondary" href="https://github.com/python-pillow/Pillow" role="button"><i class="fab fa-github mr-1"></i>View details &raquo;</a></p>
       </div>
     </div>


### PR DESCRIPTION
As of https://github.com/python-pillow/Pillow/pull/5088, Travis CI is no longer used for the main repository.

So this PR changes the Travis CI link to pillow-wheels instead.