### PR TITLE
Updated copyright year

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
     </div>
 
     <footer class="pt-3 mt-4 border-top">
-      <p>&copy; 1995-2009 Fredrik Lundh (PIL author) and contributors. &copy; 2010-2022 Alex Clark (Pillow author) and <a target="_blank" href="https://github.com/python-pillow/Pillow/graphs/contributors">contributors</a>. Logo by Alastair Houghton. Psychedelic art by Jeremy Kun.</p>
+      <p>&copy; 1995-2011 Fredrik Lundh (PIL author) and contributors. &copy; 2010-2022 Alex Clark (Pillow author) and <a target="_blank" href="https://github.com/python-pillow/Pillow/graphs/contributors">contributors</a>. Logo by Alastair Houghton. Psychedelic art by Jeremy Kun.</p>
     </footer>
   </div>
 </main>


### PR DESCRIPTION
Updated copyright year range for Fredrik Lundh, to match https://github.com/python-pillow/Pillow/blob/main/LICENSE.

I'm presuming that the main repository is correct.