### PR TITLE
Link to Mastodon with rel="me"

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,9 @@
         <li class="nav-item">
           <a class="nav-link" target="_blank" href="https://twitter.com/PythonPillow"><i class="fab fa-twitter fa-2x"></i></a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" target="_blank" href="https://fosstodon.org/@pillow" rel="me"><i class="fab fa-mastodon fa-2x"></i></a>
+        </li>
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
Link to https://fosstodon.org/@pillow and add rel="me", which will show the link as verified on  the https://fosstodon.org/@pillow profile on Mastodon:

https://docs.joinmastodon.org/user/profile/#verification

![image](https://user-images.githubusercontent.com/1324225/203267698-d803cd74-b10b-424a-bbd6-866835b78d67.png)
