### PR TITLE
Updated Gitter URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
                             <h2>Discussion</h2>
                             <p>
                                 Discussion about Pillow development, programming and technical issues occurs on <a target="_blank" href="https://github.com/python-pillow/Pillow/issues">GitHub</a>, <a target="_blank"
-    href="https://stackoverflow.com/questions/tagged/python-imaging-library">Stack Overflow</a> and <a target="_blank" href="https://gitter.im/python-pillow/Pillow">Gitter</a>.
+    href="https://stackoverflow.com/questions/tagged/python-imaging-library">Stack Overflow</a> and <a target="_blank" href="https://app.gitter.im/#/room/#python-pillow_Pillow:gitter.im">Gitter</a>.
                             </div>
                         </div>
                         <div class="col-md-4">


### PR DESCRIPTION
https://gitter.im/python-pillow/Pillow now redirects to https://app.gitter.im/#/room/#python-pillow_Pillow:gitter.im